### PR TITLE
Add a configurable branch name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ inputs:
   token:
     description: 'GitHub access token'
     required: true
+  branch:
+    description: 'Branch to commit to'
+    required: true
+    default: 'master'
   max_entries:
     description: 'Number of entries to display'
     required: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -36805,6 +36805,7 @@ const core = __nccwpck_require__(2186),
 
 const TITLE_PREFIX = 'Guestbook'
 const N_ISSUES = 10
+const BRANCH = 'master'
 const N_CHARS = 140
 const SECTION_KEY = 'guestbook'
 
@@ -36863,7 +36864,8 @@ async function updateReadme(token, context, content) {
         owner: context.repo.owner,
         repo: context.repo.repo,
         token: token,
-        section: SECTION_KEY
+        section: SECTION_KEY,
+        branch: BRANCH
     })
 }
 
@@ -36905,6 +36907,7 @@ async function run() {
 }
 
 run()
+
 })();
 
 module.exports = __webpack_exports__;

--- a/dist/index.js
+++ b/dist/index.js
@@ -36805,7 +36805,6 @@ const core = __nccwpck_require__(2186),
 
 const TITLE_PREFIX = 'Guestbook'
 const N_ISSUES = 10
-const BRANCH = 'master'
 const N_CHARS = 140
 const SECTION_KEY = 'guestbook'
 
@@ -36859,13 +36858,13 @@ async function getIssues(octokit, context, num) {
     return issues.slice(0, Math.min(issues.length, (num || N_ISSUES)))
 }
 
-async function updateReadme(token, context, content) {
+async function updateReadme(token, context, content, branch) {
     return await ReadmeBox.updateSection(content, {
         owner: context.repo.owner,
         repo: context.repo.repo,
         token: token,
         section: SECTION_KEY,
-        branch: BRANCH
+        branch: branch
     })
 }
 
@@ -36893,6 +36892,7 @@ async function run() {
     const token = core.getInput('token')
     const nIssues = core.getInput('max_entries')
     const octokit = github.getOctokit(token)
+    const branch = core.getInput('branch')
     const context = github.context
 
     const issues = await getIssues(octokit, context, nIssues)
@@ -36903,7 +36903,7 @@ async function run() {
             .replace('{2}', context.repo.repo)
             .replace('{3}', context.repo.owner)
 
-    await updateReadme(token, context, content)
+    await updateReadme(token, context, content, branch)
 }
 
 run()

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const core = require('@actions/core'),
 
 const TITLE_PREFIX = 'Guestbook'
 const N_ISSUES = 10
+const BRANCH = 'master'
 const N_CHARS = 140
 const SECTION_KEY = 'guestbook'
 
@@ -67,7 +68,8 @@ async function updateReadme(token, context, content) {
         owner: context.repo.owner,
         repo: context.repo.repo,
         token: token,
-        section: SECTION_KEY
+        section: SECTION_KEY,
+        branch: BRANCH
     })
 }
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ const core = require('@actions/core'),
 
 const TITLE_PREFIX = 'Guestbook'
 const N_ISSUES = 10
-const BRANCH = 'master'
 const N_CHARS = 140
 const SECTION_KEY = 'guestbook'
 
@@ -63,13 +62,13 @@ async function getIssues(octokit, context, num) {
     return issues.slice(0, Math.min(issues.length, (num || N_ISSUES)))
 }
 
-async function updateReadme(token, context, content) {
+async function updateReadme(token, context, content, branch) {
     return await ReadmeBox.updateSection(content, {
         owner: context.repo.owner,
         repo: context.repo.repo,
         token: token,
         section: SECTION_KEY,
-        branch: BRANCH
+        branch: branch
     })
 }
 
@@ -97,6 +96,7 @@ async function run() {
     const token = core.getInput('token')
     const nIssues = core.getInput('max_entries')
     const octokit = github.getOctokit(token)
+    const branch = core.getInput('branch')
     const context = github.context
 
     const issues = await getIssues(octokit, context, nIssues)
@@ -107,7 +107,7 @@ async function run() {
             .replace('{2}', context.repo.repo)
             .replace('{3}', context.repo.owner)
 
-    await updateReadme(token, context, content)
+    await updateReadme(token, context, content, branch)
 }
 
 run()


### PR DESCRIPTION
This adds the ability to change the branch that the action edits. This is useful for anyone who has a newer GitHub profile page that uses "main" as the default branch instead of "master".

## Example Workflow
```yaml
- name: Update guestbook
  uses: muety/readme-guestbook@?
  with:
    token: ${{ secrets.GITHUB_TOKEN }}
    branch: 'main'
```

## Backwards Compatibility
The default branch is kept as "master" which was the previous default as per the `readme-box` dependency.